### PR TITLE
split by @ instead of space

### DIFF
--- a/script_res/setdex_custom.js
+++ b/script_res/setdex_custom.js
@@ -100,7 +100,7 @@ var savecustom = function()
 		species = lines[0].substring(firstParenth + 1, lastParenth).trim();
 	}
 	else
-		species = lines[0].split(' ')[0].trim(); //species is always first
+		species = lines[0].split('@')[0].trim(); //species is always first
 	for(var i = 0; i < showdownFormes.length; ++i)
 	{
 		if(species == showdownFormes[i][0])


### PR DESCRIPTION
`.split(' ')` caused an issue where the pokemon's name was considered 'Tapu' so I changed it to `.split('@')` to remove any hypothetical items while not removing spaces.