### PR TITLE
Update setdex_smbspot.js

### DIFF
--- a/script_res/setdex_smbspot.js
+++ b/script_res/setdex_smbspot.js
@@ -3872,7 +3872,7 @@ var SETDEX_SMBSPOT={
       "evs": {
         "hp": "252",
         "df": "252",
-        "s4": "4"
+        "sd": "4"
       },
       "nature": "Bold",
       "ability": "Regenerator",

--- a/script_res/setdex_smbspot.js
+++ b/script_res/setdex_smbspot.js
@@ -2330,7 +2330,7 @@ var SETDEX_SMBSPOT={
         "at": "252",
         "sp": "252"
       },
-      "nature": "Jolly",
+      "nature": "Adamant",
       "ability": "Disguise",
       "item": "Life Orb",
       "moves": [


### PR DESCRIPTION
[11:15 AM] Meu: Why do we still have Jolly as default on the calculator
#1	Adamant	78.30785829448756%
#2	Jolly	19.43080580032051%

(Could also change the item maybe? 
#1	Fairium Z	35.275500611303514%
#2	Focus Sash	26.286172850330495%
#3	Ghostium Z	24.982342826803833%
#4	Life Orb	9.20547591561576%)