### PR TITLE
Alter Search

### DIFF
--- a/script_res/ap_calc.js
+++ b/script_res/ap_calc.js
@@ -989,7 +989,7 @@ $(document).ready(function() {
             var results = [];
             for (var i = 0; i < setOptions.length; i++) {
                 var pokeName = setOptions[i].pokemon.toUpperCase();
-                if (!query.term || pokeName.indexOf(query.term.toUpperCase()) === 0 || pokeName.indexOf("-" + query.term.toUpperCase()) >= 0 || pokeName.indexOf(" " + query.term.toUpperCase()) >= 0) {
+                if (!query.term || pokeName.indexOf(query.term.toUpperCase()) === 0 || pokeName.indexOf("" + query.term.toUpperCase()) >= 0 ) {
                     results.push(setOptions[i]);
                 }
             }


### PR DESCRIPTION
See discussion in #ps-staff on discord

[10:46 PM] lizard mouth on head: ok questions
[10:47 PM] lizard mouth on head: would you rather that the search works the way that it does now, or that it works the way that the PS calc's search works
[10:47 PM] lizard mouth on head: pics incoming bc you're probably not all familiar with the differences
[10:50 PM] lizard mouth on head: The way it currently works: you must type in the first few letters of the Poke's name (with the exception of anything with a space or a hyphen in its name such as Koko) in order for it to show up. Eg ``ari`` only shows ``Ariados``
https://cdn.discordapp.com/attachments/331773910997794818/368727267083550720/image.png
[10:51 PM] lizard mouth on head: The way PS's works: if the search term is contained anywhere within the Pokemon's name, it'll show up. ``ari`` no longer just shows ``Ariados`` but now a whole host of other things too
https://cdn.discordapp.com/attachments/331773910997794818/368727506142101506/image.png